### PR TITLE
feat(database): give full match the highest priority in fuzzy

### DIFF
--- a/src/repo/database.rs
+++ b/src/repo/database.rs
@@ -1680,6 +1680,7 @@ pub mod database_tests {
             ),
             new_test_repo(cfg, "gitlab", "my-owner-01", "my-repo-03", None),
             new_test_repo(cfg, "gitlab", "my-owner-02", "my-repo-01", None),
+            new_test_repo(cfg, "github", "jason111", "ufo-build", None),
             new_test_repo(cfg, "github", "jason222", "ufo", None),
         ]
     }

--- a/src/repo/database.rs
+++ b/src/repo/database.rs
@@ -244,6 +244,10 @@ impl Database<'_> {
         K: AsRef<str>,
     {
         let repos = self.scan(remote, "", |_remote, _owner, name, _bucket| {
+            if name == keyword.as_ref() {
+                // Full match has the highest priority, no matter what the score is.
+                return None;
+            }
             Some(name.contains(keyword.as_ref()))
         })?;
         self.get_max_score(repos)
@@ -1659,6 +1663,8 @@ pub mod database_tests {
             ),
             new_test_repo(cfg, "gitlab", "my-owner-01", "my-repo-03", None),
             new_test_repo(cfg, "gitlab", "my-owner-02", "my-repo-01", None),
+            new_test_repo(cfg, "github", "jason", "ufo-build", None),
+            new_test_repo(cfg, "github", "jason", "ufo", None),
         ]
     }
 
@@ -2093,6 +2099,13 @@ mod select_tests {
                 "gitlab".to_string(),
                 "03".to_string(),
                 "gitlab:my-owner-01/my-repo-03".to_string(),
+            ),
+            (
+                // full match has higher priority, so ufo should be returned instead of
+                // ufo-build.
+                "github".to_string(),
+                "ufo".to_string(),
+                "github:jason/ufo".to_string(),
             ),
         ];
 


### PR DESCRIPTION
Fox example, fuzzy keyword `"test"` will match repository with name
`test` rather than `test-build` now even if `test-build`'s score
is higher.

If full match hits mulitiple repositories (with same name), we will
still return the one with the highest score.
